### PR TITLE
Create items in collections

### DIFF
--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -8,7 +8,7 @@ import Button from '@mui/material/Button';
 import SelectCategories from './SelectCategories';
 
 const API_URL = 'http://localhost:5005';
-function CreateForm({ target, idObject }) {
+function CreateForm({ target, idObject, forCollection }) {
 	const { user } = useContext(AuthContext);
 
 	const [currentUser, setCurrentUser] = useState(user);
@@ -21,6 +21,7 @@ function CreateForm({ target, idObject }) {
 	const storedToken = localStorage.getItem('authToken');
 
 	const navigate = useNavigate();
+	console.log("For collection", forCollection)
 
 	useEffect(() => {
 		if (user && user._id) {
@@ -47,6 +48,7 @@ function CreateForm({ target, idObject }) {
 			imageUrl: imageUrl,
 			categories: categoryArray,
 			reviews: reviews,
+			collections: forCollection,
 		};
 
 		axios
@@ -71,6 +73,10 @@ function CreateForm({ target, idObject }) {
 		currentUser && (
 			<div className='my-3'>
 				<form className='flex flex-col' onSubmit={handleSubmit}>
+
+				<input type="hidden" name="forCollection" value={forCollection} />
+
+
 					<label htmlFor='name'>
 						Name:
 						<input

--- a/src/components/CreateForm.jsx
+++ b/src/components/CreateForm.jsx
@@ -21,7 +21,6 @@ function CreateForm({ target, idObject, forCollection }) {
 	const storedToken = localStorage.getItem('authToken');
 
 	const navigate = useNavigate();
-	console.log("For collection", forCollection)
 
 	useEffect(() => {
 		if (user && user._id) {
@@ -39,7 +38,6 @@ function CreateForm({ target, idObject, forCollection }) {
 	const handleSubmit = async (event) => {
 		event.preventDefault();
 
-		console.log(categoryArray);
 
 		const params = {
 			name: name,

--- a/src/pages/CollectionPages/MyCollection.jsx
+++ b/src/pages/CollectionPages/MyCollection.jsx
@@ -1,50 +1,61 @@
-import { Link, useParams } from "react-router-dom";
-import { useState, useEffect } from "react";
-import Button from "@mui/material/Button";
-import getCollection from "../../services/getCollection";
-import CollectionHeader from "../../components/Collections/CollectionHeader";
+import { Link, useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import Button from '@mui/material/Button';
+import getCollection from '../../services/getCollection';
+import CollectionHeader from '../../components/Collections/CollectionHeader';
+import { setCollectionId } from '../../services/sharedDatastore';
 
-const API_URL = "http://localhost:5005";
+const API_URL = 'http://localhost:5005';
 
 const MyCollection = () => {
-  const [collection, setCollection] = useState(null);
-  const { collectionId } = useParams();
+	const [collection, setCollection] = useState(null);
+	const { collectionId } = useParams();
 
-  useEffect(() => {
-    getCollection(collectionId, setCollection);
-  }, []);
+	useEffect(() => {
+		getCollection(collectionId, setCollection);
+	}, []);
 
-  // COLLECTION DETAILS RENDER
-  return (
-    <>
-      {collection && (
-        <div id="main-content" className="bg-slate-300">
-          <CollectionHeader collection={collection} />
-          <section className="p-3 pb-10">
-            {/* Collection name and description */}
-            <div>
-              <h4 className="text-2xl text-slate-600">{collection.name}</h4>
-              <p>{collection.description}</p>
-            </div>
+	// COLLECTION DETAILS RENDER
+	return (
+		<>
+			{collection && (
+				<div id='main-content' className='bg-slate-300'>
+					<CollectionHeader collection={collection} />
+					<section className='p-3 pb-10'>
+						{/* Collection name and description */}
+						<div>
+							<h4 className='text-2xl text-slate-600'>{collection.name}</h4>
+							<p>{collection.description}</p>
+						</div>
 
-            {/* Items */}
-            <div>
-              {/* Map over items here - I'll style this later so it's okay to only map over item names for now */}
-            </div>
+						{/* Items */}
+						<div>
+							{collection.items.map((item) => (
+                <div key={item._id} className='flex flex-col'>
+                  <Link to={`/my-items/${item._id}`}>
+                    <h4 className='text-2xl text-slate-600'>{item.name}</h4>
+                  </Link>
+                  <p>{item.description}</p>
+                </div>
+              ))
 
-            {/* Add new item buttone */}
-            <Link to="/create-item" className="m-2">
-              <Button variant="contained">Add new item</Button>
-            </Link>
-            {/* Edot collection buttone */}
-            <Link to={`/edit-collection/${collection._id}`}>
-              <Button>Edit Collection</Button>
-            </Link>
-          </section>
-        </div>
-      )}
-    </>
-  );
+
+      }
+						</div>
+
+						{/* Add new item buttone */}
+						<Link to='/create-item' className='m-2' onClick={() => setCollectionId(collection._id)}>
+							<Button variant='contained'>Add new item</Button>
+						</Link>
+						{/* Edot collection buttone */}
+						<Link to={`/edit-collection/${collection._id}`}>
+							<Button>Edit Collection</Button>
+						</Link>
+					</section>
+				</div>
+			)}
+		</>
+	);
 };
 
 export default MyCollection;

--- a/src/pages/ItemPages/CreateItemPage.jsx
+++ b/src/pages/ItemPages/CreateItemPage.jsx
@@ -1,12 +1,17 @@
 import CreateItemForm from "../../components/CreateItemForm";
 import ItemList from "../../components/ItemList";
 import CreateForm from "../../components/CreateForm";
+import { getCollectionId } from '../../services/sharedDatastore';
+
 
 function CreateItemPage() {
+  const collectionId = getCollectionId();
+  console.log("CollectionID", collectionId);
+
   return (
     <div id="main-content">
       <h1>Create Item</h1>
-      <CreateForm target={"items"} idObject={"item"}/>
+      <CreateForm target={"items"} idObject={"item"} forCollection={collectionId}/>
 
     </div>
   );

--- a/src/services/sharedDatastore.js
+++ b/src/services/sharedDatastore.js
@@ -1,0 +1,9 @@
+let collectionId = null;
+
+export const setCollectionId = (id) => {
+  collectionId = id;
+};
+
+export const getCollectionId = () => {
+  return collectionId;
+};


### PR DESCRIPTION
We can now create items that immediately correspond to collections.

For this, I created a sharedDatastore file which we can use as an intermediary to send the collectionId from the mycollection view through the Link to the "add item" page. on the item page, it will be sent to the backend, where we use it to a) correlate an Item with a collection (it's being created for a collection) and b) correlate the collection with the item (the item is in the collection)

In the view for the single collection I included a super rudimentary mapping function that will just list off all the items in this collection, improvement required!