### PR TITLE
Make user profiles of all users accessible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,6 +88,16 @@ function App() {
                 </IsPrivate>
               }
             />
+
+            <Route
+              path="/users/:username"
+              element={
+                <IsPrivate>
+                  <ProfilePage />
+                </IsPrivate>
+              }
+            />
+
             <Route
               path="/collections/:collectionId"
               element={

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 // import { useState, useContext } from "react";
 import { Routes, Route } from "react-router-dom";
+import { UserDataProvider } from "./context/userData.context";
 // import { AuthContext } from "./context/auth.context";
 import "./App.css";
 import Home from "./pages/Home";
@@ -71,17 +72,24 @@ function App() {
                 </IsPrivate>
               }
             />
+
             <Route
               path="/profile"
               element={
-                <IsPrivate>
-                  {" "}
-                  <ProfilePage />{" "}
-                </IsPrivate>
+                <UserDataProvider>
+                  <ProfilePage />
+                </UserDataProvider>
               }
             />
 
-            <Route path="/users/:username" element={<ProfilePage />} />
+            <Route
+              path="/users/:username"
+              element={
+                <UserDataProvider>
+                  <ProfilePage />
+                </UserDataProvider>
+              }
+            />
 
             <Route
               path="/collections"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,20 +80,14 @@ function App() {
                 </IsPrivate>
               }
             />
+
+            <Route path="/users/:username" element={<ProfilePage />} />
+
             <Route
               path="/collections"
               element={
                 <IsPrivate>
                   <Collections />
-                </IsPrivate>
-              }
-            />
-
-            <Route
-              path="/users/:username"
-              element={
-                <IsPrivate>
-                  <ProfilePage />
                 </IsPrivate>
               }
             />

--- a/src/components/Collections/CollectionHeader.jsx
+++ b/src/components/Collections/CollectionHeader.jsx
@@ -1,7 +1,14 @@
 const CollectionHeader = ({ collection }) => {
   return (
     <div id="collection-header">
-      <img src={collection.imageUrl} alt={collection.name} />
+      <img
+        src={
+          collection.imageUrl === "" || collection.imageUrl === "No image"
+            ? "/images/default/default-collection.svg"
+            : collection.imageUrl
+        }
+        alt={collection.name}
+      />
     </div>
   );
 };

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,218 +1,227 @@
-import * as React from 'react';
-import { AuthContext } from '../context/auth.context';
-import { useContext, useState } from 'react';
+import * as React from "react";
+import { AuthContext } from "../context/auth.context";
+import { useContext, useState } from "react";
 
 // MUI components
-import Box from '@mui/material/Box';
-import Drawer from '@mui/material/Drawer';
-import Button from '@mui/material/Button';
-import List from '@mui/material/List';
-import Divider from '@mui/material/Divider';
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import InboxIcon from '@mui/icons-material/MoveToInbox';
-import MailIcon from '@mui/icons-material/Mail';
-import Link from '@mui/material/Link';
+import Box from "@mui/material/Box";
+import Drawer from "@mui/material/Drawer";
+import Button from "@mui/material/Button";
+import List from "@mui/material/List";
+import Divider from "@mui/material/Divider";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import InboxIcon from "@mui/icons-material/MoveToInbox";
+import MailIcon from "@mui/icons-material/Mail";
+import Link from "@mui/material/Link";
 
 // MUI icons
-import SettingsIcon from '@mui/icons-material/Settings';
-import LogoutIcon from '@mui/icons-material/Logout';
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
-import MenuIcon from '@mui/icons-material/Menu';
-import HomeIcon from '@mui/icons-material/Home';
-import AddBoxIcon from '@mui/icons-material/AddBox';
-import BookmarksIcon from '@mui/icons-material/Bookmarks';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import EmailIcon from '@mui/icons-material/Email';
+import SettingsIcon from "@mui/icons-material/Settings";
+import LogoutIcon from "@mui/icons-material/Logout";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import MenuIcon from "@mui/icons-material/Menu";
+import HomeIcon from "@mui/icons-material/Home";
+import AddBoxIcon from "@mui/icons-material/AddBox";
+import BookmarksIcon from "@mui/icons-material/Bookmarks";
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import EmailIcon from "@mui/icons-material/Email";
 
 // -- End of Imports
 
 export default function NavBar() {
-	// Auth functions from AuthContext
-	const { isLoggedIn, user, logOutUser } = useContext(AuthContext);
+  // Auth functions from AuthContext
+  const { isLoggedIn, user, logOutUser } = useContext(AuthContext);
 
-	// Drawer navigation
-	const [state, setState] = useState({
-		left: false,
-	});
+  // Drawer navigation
+  const [state, setState] = useState({
+    left: false,
+  });
 
-				const toggleDrawer = (anchor, open) => (event) => {
-					if (event.type === 'keydown' && (event.key === 'Tab' || event.key === 'Shift')) {
-						return;
-					}
+  const toggleDrawer = (anchor, open) => (event) => {
+    if (
+      event.type === "keydown" &&
+      (event.key === "Tab" || event.key === "Shift")
+    ) {
+      return;
+    }
 
-					setState({ ...state, [anchor]: open });
-				};
+    setState({ ...state, [anchor]: open });
+  };
 
-	const list = (anchor) => (
-		<Box
-			sx={{ width: 250 }}
-			role='presentation'
-			onClick={toggleDrawer(anchor, false)}
-			onKeyDown={toggleDrawer(anchor, false)}
-		>
-			<List>
-				{/* Home */}
-				<ListItem key='Home' disablePadding>
-					<ListItemButton>
-						<ListItemIcon>
-							<HomeIcon />
-						</ListItemIcon>
-						<Link href='/' underline='none'>
-							<ListItemText primary='Home' />
-						</Link>
-					</ListItemButton>
-				</ListItem>
+  const list = (anchor) => (
+    <Box
+      sx={{ width: 250 }}
+      role="presentation"
+      onClick={toggleDrawer(anchor, false)}
+      onKeyDown={toggleDrawer(anchor, false)}
+    >
+      <List>
+        {/* Home */}
+        <ListItem key="Home" disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <HomeIcon />
+            </ListItemIcon>
+            <Link href="/" underline="none">
+              <ListItemText primary="Home" />
+            </Link>
+          </ListItemButton>
+        </ListItem>
 
-				{/* Profile */}
-				<ListItem key='Profile' disablePadding>
-					<ListItemButton>
-						<ListItemIcon>
-							<AccountCircleIcon />
-						</ListItemIcon>
-						<Link href='/profile' underline='none'>
-							<ListItemText primary='Profile' />
-						</Link>
-					</ListItemButton>
-				</ListItem>
+        {/* Profile */}
+        <ListItem key="Profile" disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <AccountCircleIcon />
+            </ListItemIcon>
+            <Link href={`/profile/${user.username}`} underline="none">
+              <ListItemText primary="Profile" />
+            </Link>
+          </ListItemButton>
+        </ListItem>
 
-				{/* Notifications */}
-				<ListItem key='Notifications' disablePadding>
-					<ListItemButton>
-						<ListItemIcon>
-							<NotificationsIcon />
-						</ListItemIcon>
-						<Link href='#' underline='none'>
-							<ListItemText primary='Notifications' />
-						</Link>
-					</ListItemButton>
-				</ListItem>
+        {/* Notifications */}
+        <ListItem key="Notifications" disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <NotificationsIcon />
+            </ListItemIcon>
+            <Link href="#" underline="none">
+              <ListItemText primary="Notifications" />
+            </Link>
+          </ListItemButton>
+        </ListItem>
 
-				{/* Messages */}
-				<ListItem key='Messages' disablePadding>
-					<ListItemButton>
-						<ListItemIcon>
-							<EmailIcon />
-						</ListItemIcon>
-						<Link href='#' underline='none'>
-							<ListItemText primary='Messages' />
-						</Link>
-					</ListItemButton>
-				</ListItem>
+        {/* Messages */}
+        <ListItem key="Messages" disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <EmailIcon />
+            </ListItemIcon>
+            <Link href="#" underline="none">
+              <ListItemText primary="Messages" />
+            </Link>
+          </ListItemButton>
+        </ListItem>
 
-				{/* Bookmarks */}
-				<ListItem key='Bookmarks' disablePadding>
-					<ListItemButton>
-						<ListItemIcon>
-							<BookmarksIcon />
-						</ListItemIcon>
-						<Link href='#' underline='none'>
-							<ListItemText primary='Bookmarks' />
-						</Link>
-					</ListItemButton>
-				</ListItem>
-			</List>
+        {/* Bookmarks */}
+        <ListItem key="Bookmarks" disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <BookmarksIcon />
+            </ListItemIcon>
+            <Link href="#" underline="none">
+              <ListItemText primary="Bookmarks" />
+            </Link>
+          </ListItemButton>
+        </ListItem>
+      </List>
 
-			{/* Settings */}
-			<ListItem key='Settings' disablePadding>
-				<ListItemButton>
-					<ListItemIcon>
-						<SettingsIcon />
-					</ListItemIcon>
-					<Link href='/profile' underline='none'>
-						<ListItemText primary='Settings' />
-					</Link>
-				</ListItemButton>
-			</ListItem>
+      {/* Settings */}
+      <ListItem key="Settings" disablePadding>
+        <ListItemButton>
+          <ListItemIcon>
+            <SettingsIcon />
+          </ListItemIcon>
+          <Link href="/profile" underline="none">
+            <ListItemText primary="Settings" />
+          </Link>
+        </ListItemButton>
+      </ListItem>
 
-			<Divider />
+      <Divider />
 
-			{/* New Collection */}
-			<ListItem key='New Collection' disablePadding>
-				<ListItemButton>
-					<ListItemIcon>
-						<AddBoxIcon />
-					</ListItemIcon>
-					<Link href='     /create-collection' underline='none'>
-						<ListItemText primary='New Collection' />
-					</Link>
-				</ListItemButton>
-			</ListItem>
+      {/* New Collection */}
+      <ListItem key="New Collection" disablePadding>
+        <ListItemButton>
+          <ListItemIcon>
+            <AddBoxIcon />
+          </ListItemIcon>
+          <Link href="     /create-collection" underline="none">
+            <ListItemText primary="New Collection" />
+          </Link>
+        </ListItemButton>
+      </ListItem>
 
-			{/* New Item */}
-			<ListItem key='New Item' disablePadding>
-				<ListItemButton>
-					<ListItemIcon>
-						<AddBoxIcon />
-					</ListItemIcon>
-					<Link href='/create-item' underline='none'>
-						<ListItemText primary='Create Item' />
-					</Link>
-				</ListItemButton>
-			</ListItem>
+      {/* New Item */}
+      <ListItem key="New Item" disablePadding>
+        <ListItemButton>
+          <ListItemIcon>
+            <AddBoxIcon />
+          </ListItemIcon>
+          <Link href="/create-item" underline="none">
+            <ListItemText primary="Create Item" />
+          </Link>
+        </ListItemButton>
+      </ListItem>
 
-			<Divider />
+      <Divider />
 
-			{/* Logout */}
-			<ListItem key='Log Out' disablePadding>
-				<ListItemButton onClick={logOutUser}>
-					<ListItemIcon>
-						<LogoutIcon />
-					</ListItemIcon>
-					<ListItemText primary='Log Out' />
-				</ListItemButton>
-			</ListItem>
-		</Box>
-	);
+      {/* Logout */}
+      <ListItem key="Log Out" disablePadding>
+        <ListItemButton onClick={logOutUser}>
+          <ListItemIcon>
+            <LogoutIcon />
+          </ListItemIcon>
+          <ListItemText primary="Log Out" />
+        </ListItemButton>
+      </ListItem>
+    </Box>
+  );
 
-	{
-		/* <IconButton color="primary" variant="text" onClick={logOutUser}>
+  {
+    /* <IconButton color="primary" variant="text" onClick={logOutUser}>
                 <LogoutIcon className="text-slate-50" />
               </IconButton> */
-	}
+  }
 
-	return (
-		<nav className='sticky shadow top-0 bg-slate-700' style={{ zIndex: 10 }}>
-			{/* BRAND LOGO */}
-			<div id='nav-bar' className='flex items-center justify-between pl-6'>
-				<Link href='/' underline='none' className='flex items-center'>
-					<h1 className='w-full text-3xl tracking-widest font-bold my-2 text-slate-50'>/USEUM</h1>
-				</Link>
+  return (
+    <nav className="sticky shadow top-0 bg-slate-700" style={{ zIndex: 10 }}>
+      {/* BRAND LOGO */}
+      <div id="nav-bar" className="flex items-center justify-between pl-6">
+        <Link href="/" underline="none" className="flex items-center">
+          <h1 className="w-full text-3xl tracking-widest font-bold my-2 text-slate-50">
+            /USEUM
+          </h1>
+        </Link>
 
-				{/* LOGGED OUT NAVBAR */}
-				{!isLoggedIn && (
-					<div className='flex items-center'>
-						<Link href='/login' className='mx-2'>
-							<Button sx={{ color: 'white' }} variant='text' size='small'>
-								Log In
-							</Button>
-						</Link>
+        {/* LOGGED OUT NAVBAR */}
+        {!isLoggedIn && (
+          <div className="flex items-center">
+            <Link href="/login" className="mx-2">
+              <Button sx={{ color: "white" }} variant="text" size="small">
+                Log In
+              </Button>
+            </Link>
 
-						<Link href='/signup'>
-							<Button variant='contained' size='small'>
-								Sign Up
-							</Button>
-						</Link>
-					</div>
-				)}
+            <Link href="/signup">
+              <Button variant="contained" size="small">
+                Sign Up
+              </Button>
+            </Link>
+          </div>
+        )}
 
-				{/* LOGGED IN NAVBAR */}
-				{isLoggedIn && (
-					<div>
-						{/* Burger menu */}
-						<React.Fragment key='left'>
-							<Button onClick={toggleDrawer('left', true)}>
-								<MenuIcon className='text-slate-50' />
-							</Button>
-							<Drawer anchor='left' open={state['left']} onClose={toggleDrawer('left', false)}>
-								{list('left')}
-							</Drawer>
-						</React.Fragment>
-					</div>
-				)}
-			</div>
-		</nav>
-	);
+        {/* LOGGED IN NAVBAR */}
+        {isLoggedIn && (
+          <div>
+            {/* Burger menu */}
+            <React.Fragment key="left">
+              <Button onClick={toggleDrawer("left", true)}>
+                <MenuIcon className="text-slate-50" />
+              </Button>
+              <Drawer
+                anchor="left"
+                open={state["left"]}
+                onClose={toggleDrawer("left", false)}
+              >
+                {list("left")}
+              </Drawer>
+            </React.Fragment>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
 }

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -75,7 +75,7 @@ export default function NavBar() {
             <ListItemIcon>
               <AccountCircleIcon />
             </ListItemIcon>
-            <Link href={`/profile/${user.username}`} underline="none">
+            <Link href={`/users/${user.username}`} underline="none">
               <ListItemText primary="Profile" />
             </Link>
           </ListItemButton>

--- a/src/components/Profile/CategoryTags.jsx
+++ b/src/components/Profile/CategoryTags.jsx
@@ -4,7 +4,7 @@ import { UserDataContext } from "../../context/userData.context";
 const CategoryTags = () => {
   const { userData } = useContext(UserDataContext);
 
-  if (userData.categories) {
+  if (userData && userData.categories) {
     return (
       <div className="mb-3">
         <div className="flex">

--- a/src/components/Profile/CategoryTags.jsx
+++ b/src/components/Profile/CategoryTags.jsx
@@ -1,11 +1,12 @@
-const CategoryTags = ({ userData }) => {
+import { useContext } from "react";
+import { UserDataContext } from "../../context/userData.context";
+
+const CategoryTags = () => {
+  const { userData } = useContext(UserDataContext);
+
   if (userData.categories) {
     return (
       <div className="mb-3">
-        {/* <span className="inline-block bg-slate-500 text-white text-xs px-2 py-1 rounded">
-        Category Name
-      </span> */}
-
         <div className="flex">
           {userData.categories.map((category) => {
             return (

--- a/src/components/Profile/CategoryTags.jsx
+++ b/src/components/Profile/CategoryTags.jsx
@@ -1,26 +1,25 @@
-const CategoryTags = ({ currentUser }) => {
-
-
-  if (currentUser.categories) {
+const CategoryTags = ({ userData }) => {
+  if (userData.categories) {
     return (
-    <div className="mb-3">
-      {/* <span className="inline-block bg-slate-500 text-white text-xs px-2 py-1 rounded">
+      <div className="mb-3">
+        {/* <span className="inline-block bg-slate-500 text-white text-xs px-2 py-1 rounded">
         Category Name
       </span> */}
 
-      <div className="flex">
-            {currentUser.categories.map((category) => {
-              return (
-                <div key={category._id} className="mr-3">
-                    <span className="inline-block bg-slate-500 text-white text-xs px-2 py-1 rounded">
-                        {category.category}
-                    </span>
-                </div>
-              );
-            })}
-          </div>
-    </div>
-  );}
+        <div className="flex">
+          {userData.categories.map((category) => {
+            return (
+              <div key={category._id} className="mr-3">
+                <span className="inline-block bg-slate-500 text-white text-xs px-2 py-1 rounded">
+                  {category.category}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
 };
 
 export default CategoryTags;

--- a/src/components/Profile/ProfileBio.jsx
+++ b/src/components/Profile/ProfileBio.jsx
@@ -6,7 +6,6 @@ import { UserDataContext } from "../../context/userData.context";
 
 const ProfileBio = () => {
   const { userData } = useContext(UserDataContext);
-  console.log(userData);
 
   return (
     <div className="grid grid-auto-rows bg-slate-600 px-4 h-30 py-2">

--- a/src/components/Profile/ProfileBio.jsx
+++ b/src/components/Profile/ProfileBio.jsx
@@ -16,7 +16,7 @@ const ProfileBio = () => {
         <div className="flex">
           {/* Username */}
           <h2 className="mr-4 self-end text-3xl text-white m-0">
-            {userData.username}
+            {userData && userData.username}
           </h2>
 
           {/* Pronouns */}
@@ -28,9 +28,7 @@ const ProfileBio = () => {
         </div>
 
         {/* Statistics (Followers, Collections, Items) */}
-        <div className="my-2">
-          <UserStatistics />
-        </div>
+        <div className="my-2">{userData && <UserStatistics />}</div>
 
         {/* UserBio */}
         <p className="text-white text-lg">
@@ -43,9 +41,7 @@ const ProfileBio = () => {
 
         {/* Display user's category/interests tags */}
         <div className="flex">
-          <div className="mr-3">
-            <CategoryTags />
-          </div>
+          <div className="mr-3">{userData && <CategoryTags />}</div>
         </div>
       </div>
     </div>

--- a/src/components/Profile/ProfileBio.jsx
+++ b/src/components/Profile/ProfileBio.jsx
@@ -1,9 +1,13 @@
+import { useContext } from "react";
 import Button from "@mui/material/Button";
 import UserStatistics from "./UserStatistics";
 import CategoryTags from "./CategoryTags";
+import { UserDataContext } from "../../context/userData.context";
 
-const ProfileBio = ({ userData }) => {
+const ProfileBio = () => {
+  const { userData } = useContext(UserDataContext);
   console.log(userData);
+
   return (
     <div className="grid grid-auto-rows bg-slate-600 px-4 h-30 py-2">
       <div className="text-right pt-3 pb-4">
@@ -26,7 +30,7 @@ const ProfileBio = ({ userData }) => {
 
         {/* Statistics (Followers, Collections, Items) */}
         <div className="my-2">
-          <UserStatistics userData={userData} />
+          <UserStatistics />
         </div>
 
         {/* UserBio */}
@@ -41,7 +45,7 @@ const ProfileBio = ({ userData }) => {
         {/* Display user's category/interests tags */}
         <div className="flex">
           <div className="mr-3">
-            <CategoryTags userData={userData} />
+            <CategoryTags />
           </div>
         </div>
       </div>

--- a/src/components/Profile/ProfileBio.jsx
+++ b/src/components/Profile/ProfileBio.jsx
@@ -2,8 +2,8 @@ import Button from "@mui/material/Button";
 import UserStatistics from "./UserStatistics";
 import CategoryTags from "./CategoryTags";
 
-const ProfileBio = ({ currentUser }) => {
-  console.log(currentUser);
+const ProfileBio = ({ userData }) => {
+  console.log(userData);
   return (
     <div className="grid grid-auto-rows bg-slate-600 px-4 h-30 py-2">
       <div className="text-right pt-3 pb-4">
@@ -13,27 +13,27 @@ const ProfileBio = ({ currentUser }) => {
         <div className="flex">
           {/* Username */}
           <h2 className="mr-4 self-end text-3xl text-white m-0">
-            {currentUser.username}
+            {userData.username}
           </h2>
 
           {/* Pronouns */}
           <i className="text-md text-white self-end p-1 ml-2">
-            {/* Should be ({currentUser.pronouns}), but waiting for updated User model and Edit profile function. Leaving placeholder for now.*/}
-            {/* ({currentUser.pronouns}) */}
+            {/* Should be ({userData.pronouns}), but waiting for updated User model and Edit profile function. Leaving placeholder for now.*/}
+            {/* ({userData.pronouns}) */}
             (they/them)
           </i>
         </div>
 
         {/* Statistics (Followers, Collections, Items) */}
         <div className="my-2">
-          <UserStatistics currentUser={currentUser} />
+          <UserStatistics userData={userData} />
         </div>
 
         {/* UserBio */}
         <p className="text-white text-lg">
-          {/* Needs to be replaced with {currentUser.userBio} once the Edit Profile function is ready.
+          {/* Needs to be replaced with {userData.userBio} once the Edit Profile function is ready.
           Leaving Lorem ipsum for testing purposes for now. */}
-          {/* {currentUser.userBio} */}
+          {/* {userData.userBio} */}
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </p>
@@ -41,7 +41,7 @@ const ProfileBio = ({ currentUser }) => {
         {/* Display user's category/interests tags */}
         <div className="flex">
           <div className="mr-3">
-            <CategoryTags currentUser={currentUser}/>
+            <CategoryTags userData={userData} />
           </div>
         </div>
       </div>

--- a/src/components/Profile/ProfileHeader.jsx
+++ b/src/components/Profile/ProfileHeader.jsx
@@ -6,7 +6,7 @@ const ProfileHeader = () => {
 
   return (
     <div className="cover">
-      <img src={userData.headerImageUrl} alt="Header image" />
+      {userData && <img src={userData.headerImageUrl} alt="Header image" />}
     </div>
   );
 };

--- a/src/components/Profile/ProfileHeader.jsx
+++ b/src/components/Profile/ProfileHeader.jsx
@@ -1,7 +1,7 @@
-const ProfileHeader = ({ currentUser }) => {
+const ProfileHeader = ({ userData }) => {
   return (
     <div className="cover">
-      <img src={currentUser.headerImageUrl} alt="Header image" />
+      <img src={userData.headerImageUrl} alt="Header image" />
     </div>
   );
 };

--- a/src/components/Profile/ProfileHeader.jsx
+++ b/src/components/Profile/ProfileHeader.jsx
@@ -1,4 +1,9 @@
-const ProfileHeader = ({ userData }) => {
+import { useContext } from "react";
+import { UserDataContext } from "../../context/userData.context";
+
+const ProfileHeader = () => {
+  const { userData } = useContext(UserDataContext);
+
   return (
     <div className="cover">
       <img src={userData.headerImageUrl} alt="Header image" />

--- a/src/components/Profile/ProfilePicture.jsx
+++ b/src/components/Profile/ProfilePicture.jsx
@@ -1,9 +1,8 @@
-const ProfilePicture = ({ currentUser }) => {
-
+const ProfilePicture = ({ userData }) => {
   return (
     <div>
       <img
-        src={currentUser.imageUrl}
+        src={userData.imageUrl}
         alt="User Profile Picture"
         className="w-40 h-40 rounded-full object-cover object-center left-0 z-5 border-4 border-slate-600"
       />

--- a/src/components/Profile/ProfilePicture.jsx
+++ b/src/components/Profile/ProfilePicture.jsx
@@ -1,15 +1,18 @@
 import { useContext } from "react";
 import { UserDataContext } from "../../context/userData.context";
+
 const ProfilePicture = () => {
   const { userData } = useContext(UserDataContext);
 
   return (
     <div>
-      <img
-        src={userData.imageUrl}
-        alt="User Profile Picture"
-        className="w-40 h-40 rounded-full object-cover object-center left-0 z-5 border-4 border-slate-600"
-      />
+      {userData && (
+        <img
+          src={userData.imageUrl}
+          alt="User Profile Picture"
+          className="w-40 h-40 rounded-full object-cover object-center left-0 z-5 border-4 border-slate-600"
+        />
+      )}
     </div>
   );
 };

--- a/src/components/Profile/ProfilePicture.jsx
+++ b/src/components/Profile/ProfilePicture.jsx
@@ -1,4 +1,8 @@
-const ProfilePicture = ({ userData }) => {
+import { useContext } from "react";
+import { UserDataContext } from "../../context/userData.context";
+const ProfilePicture = () => {
+  const { userData } = useContext(UserDataContext);
+
   return (
     <div>
       <img

--- a/src/components/Profile/UserStatistics.jsx
+++ b/src/components/Profile/UserStatistics.jsx
@@ -3,28 +3,30 @@ import { UserDataContext } from "../../context/userData.context";
 
 const UserStatistics = () => {
   const { userData } = useContext(UserDataContext);
-  console.log(userData);
 
-  return (
+  // Don't ask me why that line below makes it work magically...
+
+  if(userData.followers || userData.collections || userData.items) {
+    return (
     <div className="text-white flex">
-      {userData && (
+
         <>
           <div className="mr-4">
-            {/* <span className="font-bold">{userData.followers.length}</span>{" "} */}
+            <span className="font-bold">{userData.followers.length}</span>{" "}
             Followers
           </div>
           <div className="mr-4">
-            {/* <span className="font-bold">{userData.collections.length}</span>{" "} */}
+            <span className="font-bold">{userData.collections.length}</span>{" "}
             Collections
           </div>
           <div>
             {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
-            {/* <span className="font-bold">{userData.items.length}</span> Items */}
+            <span className="font-bold">{userData.items.length}</span> Items
           </div>
         </>
-      )}
+
     </div>
-  );
+  );}
 };
 
 export default UserStatistics;

--- a/src/components/Profile/UserStatistics.jsx
+++ b/src/components/Profile/UserStatistics.jsx
@@ -1,16 +1,22 @@
-const UserStatistics = ({ userData }) => {
+import { useContext } from "react";
+import { UserDataContext } from "../../context/userData.context";
+
+const UserStatistics = () => {
+  const { userData } = useContext(UserDataContext);
+  console.log(userData);
+
   return (
     <div className="text-white flex">
       <div className="mr-4">
-        <span className="font-bold">{userData.followers.length}</span> Followers
+        {/* <span className="font-bold">{userData.followers.length}</span> Followers */}
       </div>
       <div className="mr-4">
-        <span className="font-bold">{userData.collections.length}</span>{" "}
+        {/* <span className="font-bold">{userData.collections.length}</span>{" "} */}
         Collections
       </div>
       <div>
         {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
-        <span className="font-bold">{userData.items.length}</span> Items
+        {/* <span className="font-bold">{userData.items.length}</span> Items */}
       </div>
     </div>
   );

--- a/src/components/Profile/UserStatistics.jsx
+++ b/src/components/Profile/UserStatistics.jsx
@@ -1,18 +1,17 @@
-
 const UserStatistics = ({ currentUser }) => {
   return (
     <div className="text-white flex">
       <div className="mr-4">
-        <span className="font-bold">{currentUser.followers.length}</span>{" "}
+        {/* <span className="font-bold">{currentUser.followers.length}</span>{" "} */}
         Followers
       </div>
       <div className="mr-4">
-        <span className="font-bold">{currentUser.collections.length}</span>{" "}
+        {/* <span className="font-bold">{currentUser.collections.length}</span>{" "} */}
         Collections
       </div>
       <div>
         {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
-        <span className="font-bold">{currentUser.items.length}</span> Items
+        {/* <span className="font-bold">{currentUser.items.length}</span> Items */}
       </div>
     </div>
   );

--- a/src/components/Profile/UserStatistics.jsx
+++ b/src/components/Profile/UserStatistics.jsx
@@ -1,17 +1,17 @@
-const UserStatistics = ({ currentUser }) => {
+const UserStatistics = ({ userData }) => {
   return (
     <div className="text-white flex">
       <div className="mr-4">
-        {/* <span className="font-bold">{currentUser.followers.length}</span>{" "} */}
+        {/* <span className="font-bold">{userData.followers.length}</span>{" "} */}
         Followers
       </div>
       <div className="mr-4">
-        {/* <span className="font-bold">{currentUser.collections.length}</span>{" "} */}
+        {/* <span className="font-bold">{userData.collections.length}</span>{" "} */}
         Collections
       </div>
       <div>
         {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
-        {/* <span className="font-bold">{currentUser.items.length}</span> Items */}
+        {/* <span className="font-bold">{userData.items.length}</span> Items */}
       </div>
     </div>
   );

--- a/src/components/Profile/UserStatistics.jsx
+++ b/src/components/Profile/UserStatistics.jsx
@@ -7,17 +7,22 @@ const UserStatistics = () => {
 
   return (
     <div className="text-white flex">
-      <div className="mr-4">
-        {/* <span className="font-bold">{userData.followers.length}</span> Followers */}
-      </div>
-      <div className="mr-4">
-        {/* <span className="font-bold">{userData.collections.length}</span>{" "} */}
-        Collections
-      </div>
-      <div>
-        {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
-        {/* <span className="font-bold">{userData.items.length}</span> Items */}
-      </div>
+      {userData && (
+        <>
+          <div className="mr-4">
+            {/* <span className="font-bold">{userData.followers.length}</span>{" "} */}
+            Followers
+          </div>
+          <div className="mr-4">
+            {/* <span className="font-bold">{userData.collections.length}</span>{" "} */}
+            Collections
+          </div>
+          <div>
+            {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
+            {/* <span className="font-bold">{userData.items.length}</span> Items */}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/Profile/UserStatistics.jsx
+++ b/src/components/Profile/UserStatistics.jsx
@@ -2,16 +2,15 @@ const UserStatistics = ({ userData }) => {
   return (
     <div className="text-white flex">
       <div className="mr-4">
-        {/* <span className="font-bold">{userData.followers.length}</span>{" "} */}
-        Followers
+        <span className="font-bold">{userData.followers.length}</span> Followers
       </div>
       <div className="mr-4">
-        {/* <span className="font-bold">{userData.collections.length}</span>{" "} */}
+        <span className="font-bold">{userData.collections.length}</span>{" "}
         Collections
       </div>
       <div>
         {/* This doesn't work yet and the code might need to be altered, but I'll wait until Lukas is done updating the models. */}
-        {/* <span className="font-bold">{userData.items.length}</span> Items */}
+        <span className="font-bold">{userData.items.length}</span> Items
       </div>
     </div>
   );

--- a/src/context/userData.context.jsx
+++ b/src/context/userData.context.jsx
@@ -1,0 +1,15 @@
+import React, { useState, createContext } from "react";
+
+const UserDataContext = createContext();
+
+const UserDataProvider = ({ children }) => {
+  const [userData, setUserData] = useState({});
+
+  return (
+    <UserDataContext.Provider value={{ userData, setUserData }}>
+      {children}
+    </UserDataContext.Provider>
+  );
+};
+
+export { UserDataProvider, UserDataContext };

--- a/src/context/userData.context.jsx
+++ b/src/context/userData.context.jsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext } from "react";
+import { useState, createContext } from "react";
 
 const UserDataContext = createContext();
 

--- a/src/pages/CollectionPages/MyCollection.jsx
+++ b/src/pages/CollectionPages/MyCollection.jsx
@@ -36,7 +36,7 @@ const MyCollection = () => {
               <h4 className="text-2xl text-slate-600">{collection.name}</h4>
               <div>
                 Created by{" "}
-                <Link to={`/profile/${collection.createdBy._id}`}>
+                <Link to={`/users/${collection.createdBy.username}`}>
                   {collection.createdBy.username}
                 </Link>
               </div>

--- a/src/pages/CollectionPages/MyCollection.jsx
+++ b/src/pages/CollectionPages/MyCollection.jsx
@@ -22,7 +22,7 @@ const MyCollection = () => {
 
   useEffect(() => {
     getCollection(collectionId, setCollection);
-  }, []);
+  }, [collectionId]);
 
   // COLLECTION DETAILS RENDER
   if (collection) {
@@ -68,7 +68,7 @@ const MyCollection = () => {
             </Grid>
             {/* Add new item buttone */}
 
-            {user._id === collection.createdBy ? (
+            {user.username === collection.createdBy.username ? (
               <div className="py-4">
                 <Link
                   to="/add-item"

--- a/src/pages/CollectionPages/MyCollection.jsx
+++ b/src/pages/CollectionPages/MyCollection.jsx
@@ -32,9 +32,16 @@ const MyCollection = () => {
           <CollectionHeader collection={collection} />
           <section className="px-4 pt-3 pb-20 bg-slate-300">
             {/* Collection name and description */}
-            <div>
+            <div className="mb-4">
               <h4 className="text-2xl text-slate-600">{collection.name}</h4>
-              <p>{collection.description}</p>
+              <div>
+                Created by{" "}
+                <Link to={`/profile/${collection.createdBy._id}`}>
+                  {collection.createdBy.username}
+                </Link>
+              </div>
+
+              <div>{collection.description}</div>
             </div>
             <div>
               <h4 className="text-2xl text-slate-600">Tags</h4>

--- a/src/pages/CollectionPages/MyCollection.jsx
+++ b/src/pages/CollectionPages/MyCollection.jsx
@@ -1,12 +1,16 @@
 import { Link, useParams } from "react-router-dom";
 import { useState, useEffect, useContext } from "react";
-import Button from "@mui/material/Button";
+import { setCollectionId } from "../../services/sharedDatastore";
+import { AuthContext } from "../../context/auth.context";
 import getCollection from "../../services/getCollection";
 import CollectionHeader from "../../components/Collections/CollectionHeader";
-import { setCollectionId } from "../../services/sharedDatastore";
 import ItemCard from "../../components/Items/ItemCard";
+
+// MUI imports
+import Button from "@mui/material/Button";
 import { Grid } from "@mui/material";
-import { AuthContext } from "../../context/auth.context";
+
+// End of imports
 
 const API_URL = "http://localhost:5005";
 

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -32,9 +32,9 @@ const ProfilePage = () => {
         </div>
       </div>
 
-      <div>
+      {/* <div>
         <ProfileBio currentUser={userData} />
-      </div>
+      </div> */}
 
       <section className="px-4 pt-3 pb-20 bg-slate-300">
         <h4 className="text-2xl text-slate-600">Collections</h4>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -27,15 +27,15 @@ const ProfilePage = () => {
   return (
     <div id="main-content">
       <div className="relative">
-        <ProfileHeader userData={userData} />
+        <ProfileHeader />
         <div className="absolute mt-[-80px] mx-4">
-          <ProfilePicture userData={userData} />
+          <ProfilePicture />
         </div>
       </div>
 
-      {/* <div>
-        <ProfileBio userData={userData} />
-      </div> */}
+      <div>
+        <ProfileBio />
+      </div>
 
       <section className="px-4 pt-3 pb-20 bg-slate-300">
         <h4 className="text-2xl text-slate-600">Collections</h4>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,5 +1,4 @@
-import { AuthContext } from "../context/auth.context";
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
 import axios from "axios";
 import Button from "@mui/material/Button";
@@ -11,9 +10,8 @@ import CollectionCard from "../components/Collections/CollectionCard";
 
 const API_URL = "http://localhost:5005";
 
-// DETERMINE CURRENT USER
-const ProfilePage = ({ currentUser }) => {
-  const { username } = useParams(); // get the user ID from the URL parameter
+const ProfilePage = () => {
+  const { username } = useParams();
   const [userData, setUserData] = useState({});
 
   useEffect(() => {
@@ -22,18 +20,11 @@ const ProfilePage = ({ currentUser }) => {
       setUserData(response.data);
     };
 
-    if (username) {
-      fetchData();
-    } else {
-      setUserData(currentUser);
-    }
-  }, [username, currentUser]);
-
-  // USER PROFILE RENDER
+    fetchData();
+  }, [username]);
 
   return (
     <div id="main-content">
-      {/* Header and profile picture block */}
       <div className="relative">
         <ProfileHeader currentUser={userData} />
         <div className="absolute mt-[-80px] mx-4">
@@ -41,7 +32,6 @@ const ProfilePage = ({ currentUser }) => {
         </div>
       </div>
 
-      {/* User bio, needs to be added to User model */}
       <div>
         <ProfileBio currentUser={userData} />
       </div>
@@ -49,28 +39,18 @@ const ProfilePage = ({ currentUser }) => {
       <section className="px-4 pt-3 pb-20 bg-slate-300">
         <h4 className="text-2xl text-slate-600">Collections</h4>
         <Grid container spacing={3}>
-          {/* Available collections of this user will be rendered as cards here */}
-          {userData.collections.length < 1 ? (
+          {userData.collections && userData.collections ? (
+            userData.collections.map((collection) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={collection._id}>
+                <CollectionCard key={collection._id} collection={collection} />
+              </Grid>
+            ))
+          ) : (
             <Grid item xs={12} sm={6} md={4} lg={3}>
               <p>No collections available</p>
             </Grid>
-          ) : (
-            userData.collections.map((collection) => {
-              return (
-                <>
-                  <Grid item xs={12} sm={6} md={4} lg={3} key={collection._id}>
-                    <CollectionCard
-                      key={collection._id}
-                      collection={collection}
-                    />
-                  </Grid>
-                </>
-              );
-            })
           )}
         </Grid>
-
-        {/* Add new collection button */}
 
         <nav className="my-4">
           <Link to="/create-collection" className="m-2">

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,5 +1,5 @@
 import { AuthContext } from "../context/auth.context";
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useParams } from "react";
 import { Link } from "react-router-dom";
 import axios from "axios";
 import Button from "@mui/material/Button";

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,6 +1,6 @@
 import { AuthContext } from "../context/auth.context";
-import { useState, useEffect, useContext, useParams } from "react";
-import { Link } from "react-router-dom";
+import { useState, useEffect, useContext } from "react";
+import { Link, useParams } from "react-router-dom";
 import axios from "axios";
 import Button from "@mui/material/Button";
 import { Grid } from "@mui/material";
@@ -13,6 +13,7 @@ const API_URL = "http://localhost:5005";
 
 // DETERMINE CURRENT USER
 const ProfilePage = () => {
+  const { username } = useParams(); // get the user ID from the URL parameter
   const { user } = useContext(AuthContext);
 
   const [currentUser, setCurrentUser] = useState(user);

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -32,9 +32,9 @@ const ProfilePage = () => {
         </div>
       </div>
 
-      {/* <div>
+      <div>
         <ProfileBio currentUser={userData} />
-      </div> */}
+      </div>
 
       <section className="px-4 pt-3 pb-20 bg-slate-300">
         <h4 className="text-2xl text-slate-600">Collections</h4>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -26,14 +26,14 @@ const ProfilePage = () => {
   return (
     <div id="main-content">
       <div className="relative">
-        <ProfileHeader currentUser={userData} />
+        <ProfileHeader userData={userData} />
         <div className="absolute mt-[-80px] mx-4">
-          <ProfilePicture currentUser={userData} />
+          <ProfilePicture userData={userData} />
         </div>
       </div>
 
       <div>
-        <ProfileBio currentUser={userData} />
+        <ProfileBio userData={userData} />
       </div>
 
       <section className="px-4 pt-3 pb-20 bg-slate-300">

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -12,86 +12,74 @@ import CollectionCard from "../components/Collections/CollectionCard";
 const API_URL = "http://localhost:5005";
 
 // DETERMINE CURRENT USER
-const ProfilePage = () => {
+const ProfilePage = ({ currentUser }) => {
   const { username } = useParams(); // get the user ID from the URL parameter
-  const { user } = useContext(AuthContext);
-
-  const [currentUser, setCurrentUser] = useState(user);
+  const [userData, setUserData] = useState({});
 
   useEffect(() => {
-    if (user && user._id) {
-      axios
-        .get(`${API_URL}/users/${user._id}`)
-        .then((res) => {
-          setCurrentUser(res.data);
-          console.log(res.data);
-        })
-        .catch((err) => {
-          console.error(err);
-        });
+    const fetchData = async () => {
+      const response = await axios.get(`${API_URL}/users/${username}`);
+      setUserData(response.data);
+    };
+
+    if (username) {
+      fetchData();
+    } else {
+      setUserData(currentUser);
     }
-  }, [user]);
+  }, [username, currentUser]);
 
   // USER PROFILE RENDER
 
-  if (currentUser.categories || currentUser.collections) {
-    return (
-      <div id="main-content">
-        {/* Header and profile picture block */}
-        <div className="relative">
-          <ProfileHeader currentUser={currentUser} />
-          <div className="absolute mt-[-80px] mx-4">
-            <ProfilePicture currentUser={currentUser} />
-          </div>
+  return (
+    <div id="main-content">
+      {/* Header and profile picture block */}
+      <div className="relative">
+        <ProfileHeader currentUser={userData} />
+        <div className="absolute mt-[-80px] mx-4">
+          <ProfilePicture currentUser={userData} />
         </div>
-
-        {/* User bio, needs to be added to User model */}
-        <div>
-          <ProfileBio currentUser={currentUser} />
-        </div>
-
-        <section className="px-4 pt-3 pb-20 bg-slate-300">
-          <h4 className="text-2xl text-slate-600">Collections</h4>
-          <Grid container spacing={3}>
-            {/* Available collections of this user will be rendered as cards here */}
-            {currentUser.collections.length < 1 ? (
-              <Grid item xs={12} sm={6} md={4} lg={3}>
-                <p>No collections available</p>
-              </Grid>
-            ) : (
-              currentUser.collections.map((collection) => {
-                return (
-                  <>
-                    <Grid
-                      item
-                      xs={12}
-                      sm={6}
-                      md={4}
-                      lg={3}
-                      key={collection._id}
-                    >
-                      <CollectionCard
-                        key={collection._id}
-                        collection={collection}
-                      />
-                    </Grid>
-                  </>
-                );
-              })
-            )}
-          </Grid>
-
-          {/* Add new collection button */}
-
-          <nav className="my-4">
-            <Link to="/create-collection" className="m-2">
-              <Button variant="contained">New collection</Button>
-            </Link>
-          </nav>
-        </section>
       </div>
-    );
-  }
+
+      {/* User bio, needs to be added to User model */}
+      <div>
+        <ProfileBio currentUser={userData} />
+      </div>
+
+      <section className="px-4 pt-3 pb-20 bg-slate-300">
+        <h4 className="text-2xl text-slate-600">Collections</h4>
+        <Grid container spacing={3}>
+          {/* Available collections of this user will be rendered as cards here */}
+          {userData.collections.length < 1 ? (
+            <Grid item xs={12} sm={6} md={4} lg={3}>
+              <p>No collections available</p>
+            </Grid>
+          ) : (
+            userData.collections.map((collection) => {
+              return (
+                <>
+                  <Grid item xs={12} sm={6} md={4} lg={3} key={collection._id}>
+                    <CollectionCard
+                      key={collection._id}
+                      collection={collection}
+                    />
+                  </Grid>
+                </>
+              );
+            })
+          )}
+        </Grid>
+
+        {/* Add new collection button */}
+
+        <nav className="my-4">
+          <Link to="/create-collection" className="m-2">
+            <Button variant="contained">New collection</Button>
+          </Link>
+        </nav>
+      </section>
+    </div>
+  );
 };
 
 export default ProfilePage;

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
+import { UserDataContext } from "../context/userData.context";
 import axios from "axios";
 import Button from "@mui/material/Button";
 import { Grid } from "@mui/material";
@@ -12,7 +13,7 @@ const API_URL = "http://localhost:5005";
 
 const ProfilePage = () => {
   const { username } = useParams();
-  const [userData, setUserData] = useState({});
+  const { userData, setUserData } = useContext(UserDataContext);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -21,7 +22,7 @@ const ProfilePage = () => {
     };
 
     fetchData();
-  }, [username]);
+  }, [username, setUserData]);
 
   return (
     <div id="main-content">
@@ -32,9 +33,9 @@ const ProfilePage = () => {
         </div>
       </div>
 
-      <div>
+      {/* <div>
         <ProfileBio userData={userData} />
-      </div>
+      </div> */}
 
       <section className="px-4 pt-3 pb-20 bg-slate-300">
         <h4 className="text-2xl text-slate-600">Collections</h4>


### PR DESCRIPTION
- Profiles are now accessible through the /users/:username route

- Collection pages now display an unstyled link to the collection owner's user profile.

- Created a userData context to handle the requested data instead of the previous prop drilling

- The code still renders edit buttons, etc. even on other user profiles, but I'll do that in a new branch because there are A LOT OF CHANGES in this one already that likely need to be tweaked or improved.

- For some reason I wasn't able to make the UserStatistics.jsx work again. The .length function keeps causing errors, so they're uncommented for now. It's best to look at this again once the updated user models are on the server.

- It's not possible to view the details of Lukas' collections from the seed files anymore because they lack a createdBy property which is needed to show the link to the collection owner's profile. I could've built a condition around this, but it's better if we stop injecting more conditionals to work around the incomplete data sets.

Please donate new braincells, my current ones are completely fried.